### PR TITLE
update Ledger Rust SDK deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 arrayvec = { version = "0.7.1", default-features = false }
 
 [target.'cfg(target_family = "bolos")'.dependencies]
-ledger_device_sdk = { version = "1.28.0" }
+ledger_device_sdk = { version = "1.29.0" }
 
 [features]
 speculos = ["ledger_device_sdk/speculos"]
@@ -19,6 +19,3 @@ log_warn = ["log_error"]
 log_info = ["log_warn"]
 log_debug = ["log_info"]
 log_trace = ["log_debug"]
-
-[patch.crates-io]
-ledger_device_sdk = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 arrayvec = { version = "0.7.1", default-features = false }
 
 [target.'cfg(target_family = "bolos")'.dependencies]
-ledger_device_sdk = "1.4.3"
+ledger_device_sdk = { version = "1.28.0" }
 
 [features]
 speculos = ["ledger_device_sdk/speculos"]
@@ -19,3 +19,6 @@ log_warn = ["log_error"]
 log_info = ["log_warn"]
 log_debug = ["log_info"]
 log_trace = ["log_debug"]
+
+[patch.crates-io]
+ledger_device_sdk = { git = "https://github.com/LedgerHQ/ledger-device-rust-sdk.git" }


### PR DESCRIPTION
This PR updates the Ledger Rust SDK dependencies: sys crate is now available through the sys feature.
PR should be merged when the new `ledger_device_sdk` crate ( version > 1.28) will be published on crates.io.